### PR TITLE
feat: return count of changed rows from commands

### DIFF
--- a/odor/src/main/scala/PostgresClient.scala
+++ b/odor/src/main/scala/PostgresClient.scala
@@ -78,8 +78,8 @@ class PostgresClient(val pool: PostgresConnectionPool, connection: PoolClient)(i
   def command[PARAMS](
     command: Command[PARAMS],
     params: PARAMS = Void,
-  ): Future[Unit] = async {
-    await(
+  ): Future[Int] = async {
+    val result = await(
       connection
         .query(
           command.sql,
@@ -87,7 +87,7 @@ class PostgresClient(val pool: PostgresConnectionPool, connection: PoolClient)(i
         )
         .toFuture,
     )
-    ()
+    result.rowCount.toInt
   }
 
   def query[PARAMS, ROW](
@@ -130,7 +130,7 @@ class PostgresClient(val pool: PostgresConnectionPool, connection: PoolClient)(i
 object PostgresClient {
   class Transaction(
     transactionSemaphore: Future[Semaphore[IO]],
-    command: Command[Void] => Future[Unit],
+    command: Command[Void] => Future[Int],
   )(implicit ec: ExecutionContext) {
 
     private var recursion = 0

--- a/odor/src/test/scala/PgClientSpec.scala
+++ b/odor/src/test/scala/PgClientSpec.scala
@@ -24,7 +24,7 @@ class PgClientSpecUnitTests extends AsyncFlatSpec with BeforeAndAfterEach {
 
   val tx = new PostgresClient.Transaction(
     transactionSemaphore = semaphore,
-    command = c => Future.successful(buffer += c.sql),
+    command = c => Future.successful { buffer += c.sql; 0 },
   )
 
   def delay(delayMs: Long): Future[Unit] = {
@@ -162,7 +162,7 @@ class PgClientSpecUnitTests extends AsyncFlatSpec with BeforeAndAfterEach {
     while (i < 2) {
       val tx = new PostgresClient.Transaction(
         transactionSemaphore = semaphore,
-        command = c => if (c.sql == failedSql(i)) Future.failed(connFail) else Future.successful(buffer += c.sql),
+        command = c => if (c.sql == failedSql(i)) Future.failed(connFail) else Future.successful { buffer += c.sql; 0 },
       )
 
       assert(await(tx {
@@ -191,7 +191,7 @@ class PgClientSpecUnitTests extends AsyncFlatSpec with BeforeAndAfterEach {
 
     val tx = new PostgresClient.Transaction(
       transactionSemaphore = semaphore,
-      command = c => if (c.sql == "ROLLBACK") Future.failed(connFail) else Future.successful(buffer += c.sql),
+      command = c => if (c.sql == "ROLLBACK") Future.failed(connFail) else Future.successful { buffer += c.sql; 0 },
     )
 
     assert(await(tx {
@@ -206,5 +206,4 @@ class PgClientSpecUnitTests extends AsyncFlatSpec with BeforeAndAfterEach {
     assert(await(await(semaphore).available.unsafeToFuture()) == 1)
 
   }
-
 }


### PR DESCRIPTION
For commands, i.e., `UPDATE`, `INSERT`, etc., `result.rowCount` contains the number of rows that were changed by the command.

Corresponding node-postgres docs: https://node-postgres.com/apis/result#resultrowcount-int